### PR TITLE
Refactor updaters and implement Blue Star awards

### DIFF
--- a/update_quality.rb
+++ b/update_quality.rb
@@ -1,49 +1,19 @@
 require 'award'
+Dir[File.join(__dir__, 'updaters', '*.rb')].each { |file| require file }
 
-def update_quality(awards)
+def update_quality(awards)  
   awards.each do |award|
-    if award.name != 'Blue First' && award.name != 'Blue Compare'
-      if award.quality > 0
-        if award.name != 'Blue Distinction Plus'
-          award.quality -= 1
-        end
-      end
+    case award.name
+    when "Blue First"
+      BlueFirstUpdater.update(award)
+    when "Blue Compare"
+      BlueCompareUpdater.update(award)
+    when "Blue Distinction Plus"
+      BlueDistinctionPlusUpdater.update(award)
+    when "Blue Star"
+      BlueStarUpdater.update(award)
     else
-      if award.quality < 50
-        award.quality += 1
-        if award.name == 'Blue Compare'
-          if award.expires_in < 11
-            if award.quality < 50
-              award.quality += 1
-            end
-          end
-          if award.expires_in < 6
-            if award.quality < 50
-              award.quality += 1
-            end
-          end
-        end
-      end
-    end
-    if award.name != 'Blue Distinction Plus'
-      award.expires_in -= 1
-    end
-    if award.expires_in < 0
-      if award.name != 'Blue First'
-        if award.name != 'Blue Compare'
-          if award.quality > 0
-            if award.name != 'Blue Distinction Plus'
-              award.quality -= 1
-            end
-          end
-        else
-          award.quality = award.quality - award.quality
-        end
-      else
-        if award.quality < 50
-          award.quality += 1
-        end
-      end
+      GenericAwardUpdater.update(award)
     end
   end
 end

--- a/update_quality_spec.rb
+++ b/update_quality_spec.rb
@@ -177,7 +177,6 @@ describe '#update_quality' do
       end
 
       context 'given a Blue Star award' do
-        before { pending }
         let(:name) { 'Blue Star' }
         before { award.expires_in.should == initial_expires_in-1 }
 

--- a/updaters/blue_compare_updater.rb
+++ b/updaters/blue_compare_updater.rb
@@ -1,0 +1,21 @@
+class BlueCompareUpdater 
+  def self.update(award)
+    award.quality += 1 unless award.quality >= 50
+    quality_increase_when_less_than(11, award)
+    quality_increase_when_less_than(6, award)
+
+    award.expires_in -= 1
+
+    if award.expires_in < 0
+      award.quality = 0
+    end
+
+    award
+  end
+
+  def self.quality_increase_when_less_than(days, award)
+    if award.expires_in < days
+      award.quality += 1 unless award.quality >= 50
+    end
+  end
+end

--- a/updaters/blue_distinction_plus_updater.rb
+++ b/updaters/blue_distinction_plus_updater.rb
@@ -1,0 +1,9 @@
+class BlueDistinctionPlusUpdater
+  # Never decreases in quality, simply return the same award without change.
+  # Per business logic, quality should be 80 and never alter.
+  def self.update(award)
+    raise StandardError.new "Award Type 'Blue Distinction Plus' must be of 80 quality" unless award.quality == 80
+
+    award
+  end
+end

--- a/updaters/blue_first_updater.rb
+++ b/updaters/blue_first_updater.rb
@@ -1,0 +1,18 @@
+class BlueFirstUpdater
+  def self.update(award)
+    award.quality += 1 unless award.quality >= 50
+    award.expires_in -= 1
+
+    if award.expires_in < 0
+      award.quality += 1 unless award.quality >= 50
+    end
+
+    award
+  end
+
+  def self.quality_increase_when_less_than(days, award)
+    if award.expires_in < days
+      award.quality += 1 unless award.quality >= 50
+    end
+  end
+end

--- a/updaters/blue_star_updater.rb
+++ b/updaters/blue_star_updater.rb
@@ -1,0 +1,10 @@
+class BlueStarUpdater
+  def self.update(award)
+    quality_degradation_rate = 2 * (award.expires_in <= 0 ? 2 : 1)
+
+    award.quality -= quality_degradation_rate
+    award.quality = 0 if award.quality < 0
+    
+    award.expires_in -= 1
+  end
+end

--- a/updaters/generic_award_updater.rb
+++ b/updaters/generic_award_updater.rb
@@ -1,0 +1,12 @@
+class GenericAwardUpdater  
+  def self.update(award)
+    award.quality -= 1 unless award.quality.zero?
+    award.expires_in -= 1
+
+    if award.expires_in < 0
+      award.quality -= 1 unless award.quality.zero?
+    end
+
+    award
+  end
+end


### PR DESCRIPTION
Roughly 2 hours of work as requested.

1. The award updater logic for each award type have been isolated, and are now in a folder which gets loaded.
2. All tests passing -- Only change to test suite was removing the pending flag from Blue Star
3. Implemented Blue Star with the requested logic.

Improvements if given more time:
1. Possibly clean up the test suite -- Isolate the tests to each individual updater class.
2. There is probably some room to DRY-up the Blue Compare and Blue First updater classes, but who knows if those two could deviate further in the future, so I didn't spend any time there: I figured any time spent might be completely wasted if more business logic came later.
3. Some error handling around the main class, verifying that what's given to the update_quality method is actually an array of Award objects.
4. Distinction Plus doesn't actually have a test for verifying that an incoming award is not already 80.  I added a simple StandardError but that branch of the code never executes given the existing test suite.  Add a case to the test suite for this, and get guidance from product owner on what to do if one such award did somehow enter the system.