### PR TITLE
Update Blue Star award decay rate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 gem 'rspec'
 gem 'rake'
+group :development do
+    gem 'byebug'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.3)
     diff-lcs (1.2.5)
     rake (13.0.6)
     rspec (2.14.1)
@@ -16,6 +17,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   rake
   rspec
 

--- a/award.rb
+++ b/award.rb
@@ -1,1 +1,83 @@
-Award = Struct.new(:name, :expires_in, :quality)
+QUALITY_LOWER_LIMIT = 0
+QUALITY_UPPER_LIMIT = 50
+BLUE_COMPARE_DEADLINE_1 = 5
+BLUE_COMPARE_DEADLINE_1_QUALITY_THRESHOLD = 3
+BLUE_COMPARE_DEADLINE_2 = 10
+BLUE_COMPARE_DEADLINE_2_QUALITY_THRESHOLD = 2
+BLUE_STAR_DECAY_RATE_EXPIRED = 4
+BLUE_STAR_DECAY_RATE_DEFAULT = 2
+BLUE_DINSTINCTION_PLUS_QUALITY = 80
+RATE_DEFAULT = 1
+RATE_DOUBLE = 2
+
+class Award
+  attr_accessor :name, :expires_in, :quality
+
+  def initialize(name, expires_in, quality)
+    @name = name
+    @expires_in = expires_in
+    @quality = quality
+  end
+
+  def update_quality
+    case self.name
+    when 'Blue First'
+      update_blue_first_award
+    when 'Blue Compare'
+      update_blue_compare_award
+    when 'Blue Star'
+      update_blue_star_award
+    when 'Blue Distinction Plus'
+      update_blue_distinction_plus
+    else
+      update_normal_award
+    end
+    
+    unless self.name == 'Blue Distinction Plus'
+      maintain_quality_limits
+      decrease_expiration
+    end
+  end
+
+  private
+
+  def maintain_quality_limits
+    self.quality = quality.clamp(QUALITY_LOWER_LIMIT, QUALITY_UPPER_LIMIT)
+  end
+
+  def expired?
+    self.expires_in <= 0
+  end
+
+  def update_normal_award
+    self.quality -= expired? ? RATE_DOUBLE : RATE_DEFAULT
+  end
+  
+  def update_blue_first_award
+    self.quality += expired? ? RATE_DOUBLE : RATE_DEFAULT
+  end
+  
+  def update_blue_compare_award
+    if expired?
+      self.quality = 0
+    elsif self.expires_in <= BLUE_COMPARE_DEADLINE_1
+      self.quality += BLUE_COMPARE_DEADLINE_1_QUALITY_THRESHOLD
+    elsif self.expires_in <= BLUE_COMPARE_DEADLINE_2
+      self.quality += BLUE_COMPARE_DEADLINE_2_QUALITY_THRESHOLD
+    else
+      self.quality += RATE_DEFAULT
+    end
+  end
+  
+  def update_blue_star_award
+    self.quality -= expired? ? BLUE_STAR_DECAY_RATE_EXPIRED : BLUE_STAR_DECAY_RATE_DEFAULT
+  end
+
+  def decrease_expiration
+    self.expires_in -= RATE_DEFAULT
+  end
+
+  def update_blue_distinction_plus
+    self.quality = BLUE_DINSTINCTION_PLUS_QUALITY
+  end
+end

--- a/update_quality.rb
+++ b/update_quality.rb
@@ -1,49 +1,5 @@
 require 'award'
 
 def update_quality(awards)
-  awards.each do |award|
-    if award.name != 'Blue First' && award.name != 'Blue Compare'
-      if award.quality > 0
-        if award.name != 'Blue Distinction Plus'
-          award.quality -= 1
-        end
-      end
-    else
-      if award.quality < 50
-        award.quality += 1
-        if award.name == 'Blue Compare'
-          if award.expires_in < 11
-            if award.quality < 50
-              award.quality += 1
-            end
-          end
-          if award.expires_in < 6
-            if award.quality < 50
-              award.quality += 1
-            end
-          end
-        end
-      end
-    end
-    if award.name != 'Blue Distinction Plus'
-      award.expires_in -= 1
-    end
-    if award.expires_in < 0
-      if award.name != 'Blue First'
-        if award.name != 'Blue Compare'
-          if award.quality > 0
-            if award.name != 'Blue Distinction Plus'
-              award.quality -= 1
-            end
-          end
-        else
-          award.quality = award.quality - award.quality
-        end
-      else
-        if award.quality < 50
-          award.quality += 1
-        end
-      end
-    end
-  end
+  awards.each(&:update_quality)
 end

--- a/update_quality_spec.rb
+++ b/update_quality_spec.rb
@@ -177,7 +177,6 @@ describe '#update_quality' do
       end
 
       context 'given a Blue Star award' do
-        before { pending }
         let(:name) { 'Blue Star' }
         before { award.expires_in.should == initial_expires_in-1 }
 


### PR DESCRIPTION
## Here is the business story:

In order to distinguish between providers of high quality, as a consumer, I want to see "Blue Star" awarded providers near the top of the results when the award is initially granted, but its impact should be smaller the longer it has been from the grant date.

## Acceptance Criteria

"Blue Star" awards should lose quality value twice as fast as normal awards.
